### PR TITLE
Fix: turn off set -u for conda activate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Prove that flake8 is installed
       uses: ./
       with:
-        args: flake8 --version
+        args: flake8 .
     - name: Prove that Pytest is installed
       uses: ./
       with:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Conda-Action
 
 This action runs a container from Ubuntu with Miniconda3 installed. It creates
-and activates a Conda environment `--prefix="${GITHUB_WORKSPACE}/.myenv"`. You
+and activates a Conda environment `--prefix="${HOME}/myenv"`. You
 can update the environment with your project's requirement file, and run your
 logic in the Conda environment for subsequent steps in the job.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Conda-Action
 
 This action runs a container from Ubuntu with Miniconda3 installed. It creates
-and activates a Conda environment `--prefix="${GITHUB_WORKSPACE}/myenv"`. You
+and activates a Conda environment `--prefix="${GITHUB_WORKSPACE}/.myenv"`. You
 can update the environment with your project's requirement file, and run your
 logic in the Conda environment for subsequent steps in the job.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,7 @@ set -eu
 set -o pipefail
 
 main() {
+    set -x
     local ENV_PREFIX="${GITHUB_WORKSPACE}/myenv"
     . '/opt/conda/etc/profile.d/conda.sh'
     if ! conda activate "${ENV_PREFIX}" 2>'/dev/null'; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@ set -eu
 set -o pipefail
 
 main() {
-    local ENV_PREFIX="${GITHUB_WORKSPACE}/.myenv"
+    local ENV_PREFIX="${HOME}/myenv"
     . '/opt/conda/etc/profile.d/conda.sh'
     set +u
     if ! conda activate "${ENV_PREFIX}"; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ main() {
     set -x
     local ENV_PREFIX="${GITHUB_WORKSPACE}/myenv"
     . '/opt/conda/etc/profile.d/conda.sh'
-    if ! conda activate "${ENV_PREFIX}" 2>'/dev/null'; then
+    if ! conda activate "${ENV_PREFIX}"; then
         conda create -y -p "${ENV_PREFIX}"
         conda activate "${ENV_PREFIX}"
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,10 +6,12 @@ main() {
     set -x
     local ENV_PREFIX="${GITHUB_WORKSPACE}/myenv"
     . '/opt/conda/etc/profile.d/conda.sh'
+    set +u
     if ! conda activate "${ENV_PREFIX}"; then
         conda create -y -p "${ENV_PREFIX}"
         conda activate "${ENV_PREFIX}"
     fi
+    set -u
     if (($# != 0)); then
         "$@"
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,7 @@ set -eu
 set -o pipefail
 
 main() {
-    set -x
-    local ENV_PREFIX="${GITHUB_WORKSPACE}/myenv"
+    local ENV_PREFIX="${GITHUB_WORKSPACE}/.myenv"
     . '/opt/conda/etc/profile.d/conda.sh'
     set +u
     if ! conda activate "${ENV_PREFIX}"; then

--- a/test/test_me.py
+++ b/test/test_me.py
@@ -1,5 +1,6 @@
 """This is used for testing that pytest is doing some stuffs."""
 
+
 def test_me():
     """1 + 1 == 2"""
     assert 1 + 1 == 2


### PR DESCRIPTION
On using this action in another project, I got a failure with no error. On adding an xtrace, it reveals that `set -u` was causing `conda activate` to fail. This change switches off `set -u` temporarily when running `conda ...` to avoid this.

I have also modified the location of the Conda environment so it does not live in PWD (where the source tree also lives), so tools won't pick up the 3rd party source file installed the environment.